### PR TITLE
Increased pad from 5 to 20

### DIFF
--- a/molvecgen/vectorizers.py
+++ b/molvecgen/vectorizers.py
@@ -15,7 +15,7 @@ class SmilesVectorizer(object):
     :parameter canonical: use canonical SMILES during transform (overrides enum)
     :parameter binary: Use RDKit binary strings instead of molecule objects
     """
-    def __init__(self, charset = '@C)(=cOn1S2/H[N]\\', pad=5, maxlength=120, leftpad=True, isomericSmiles=True, augment=True, canonical=False, startchar = '^', endchar = '$', unknownchar = '?', binary=False):
+    def __init__(self, charset = '@C)(=cOn1S2/H[N]\\', pad=20, maxlength=120, leftpad=True, isomericSmiles=True, augment=True, canonical=False, startchar = '^', endchar = '$', unknownchar = '?', binary=False):
         #Special Characters
         self.startchar = startchar
         self.endchar = endchar


### PR DESCRIPTION
Increased pad from 5 to 20 characters to avoid breaking of training when using the MOSES benchmark's dataset, because of generated SMILES strings that are longer than the allowed (maxlen+pad).